### PR TITLE
Added darkmode support

### DIFF
--- a/conf/example-singleServer-full.html
+++ b/conf/example-singleServer-full.html
@@ -272,6 +272,25 @@ function initUI(){
 			font-size:0.8em;
 		}
 	}
+	@media all and (prefers-color-scheme: dark){
+		html,body,#loading{
+			background:#202020;
+			color:#F4F4F4;
+			color-scheme:dark;
+		}
+		h1{
+			color:#E0E0E0;
+		}
+		a{
+			color:#9090FF;
+		}
+		#privacyPolicy{
+			background:#000000;
+		}
+		#resultsImg{
+			filter: invert(1);
+		}
+	}
 </style>
 <title>LibreSpeed YunoHost</title>
 </head>


### PR DESCRIPTION
## Problem

- The LibreSpeed YunoHost package does not support dark mode based on the system color scheme, unlike upstream LibreSpeed.

## Solution

Added CSS rules to enable dark mode support, consistent with upstream:

```css
@media all and (prefers-color-scheme: dark){
    html,body,#loading{
        background:#202020;
        color:#F4F4F4;
        color-scheme:dark;
    }
    h1{
        color:#E0E0E0;
    }
    a{
        color:#9090FF;
    }
    #privacyPolicy{
        background:#000000;
    }
    #resultsImg{
        filter: invert(1);
    }
}
```

## Tests

- [x] Tested in a fresh YunoHost VM

- [x] No breaking changes

- [x] Default fallback remains light mode

Installation logs :
https://paste.yunohost.org/raw/awabuvumip

Screens :
Darkmode enabled in my system
<img width="1616" height="1744" alt="image" src="https://github.com/user-attachments/assets/cae34eea-0999-497e-b611-6d4483e72de1" />

Darkmode disabled in my system
<img width="1616" height="1744" alt="image" src="https://github.com/user-attachments/assets/b10fd815-5ba0-4601-aaa0-66f584d76923" />

---

ℹ️ Note: This is my first real PR to an open source project, feedback is welcome 🙂
